### PR TITLE
refactor: use relative imports

### DIFF
--- a/src/interfaces/IBaseTrigger.sol
+++ b/src/interfaces/IBaseTrigger.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: Unlicensed
 pragma solidity ^0.8.0;
 
-import "src/interfaces/IManager.sol";
-import "src/interfaces/ITrigger.sol";
+import "./IManager.sol";
+import "./ITrigger.sol";
 
 /**
  * @dev Additional functions that are recommended to have in a trigger, but are not required.

--- a/src/interfaces/IChainlinkTrigger.sol
+++ b/src/interfaces/IChainlinkTrigger.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.0;
 
 import "chainlink/contracts/src/v0.8/interfaces/AggregatorV3Interface.sol";
-import "src/interfaces/IManager.sol";
+import "./IManager.sol";
 
 /**
  * @notice A trigger contract that takes two addresses: a truth oracle and a tracking oracle.

--- a/src/interfaces/IChainlinkTriggerFactory.sol
+++ b/src/interfaces/IChainlinkTriggerFactory.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Unlicensed
 pragma solidity ^0.8.0;
 
-import "src/interfaces/IChainlinkTrigger.sol";
+import "./IChainlinkTrigger.sol";
 
 /**
  * @notice Deploys Chainlink triggers that ensure two oracles stay within the given price

--- a/src/interfaces/IConfig.sol
+++ b/src/interfaces/IConfig.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: Unlicensed
 pragma solidity ^0.8.0;
 
-import "src/interfaces/ICostModel.sol";
-import "src/interfaces/IDripDecayModel.sol";
+import "./ICostModel.sol";
+import "./IDripDecayModel.sol";
 
 /**
  * @dev Structs used to define parameters in sets and markets.

--- a/src/interfaces/ICozyLens.sol
+++ b/src/interfaces/ICozyLens.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: Unlicensed
 pragma solidity ^0.8.0;
 
-import "src/interfaces/IPToken.sol";
-import "src/interfaces/ISet.sol";
+import "./IPToken.sol";
+import "./ISet.sol";
 
 /**
  * @notice Helper contract for reading data from the Cozy protocol.

--- a/src/interfaces/ICozyMetadataRegistry.sol
+++ b/src/interfaces/ICozyMetadataRegistry.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Unlicensed
 pragma solidity ^0.8.0;
 
-import "src/interfaces/ISet.sol";
+import "./ISet.sol";
 
 interface ICozyMetadataRegistry {
   /// @notice Required metadata for a given set or trigger.

--- a/src/interfaces/ILFT.sol
+++ b/src/interfaces/ILFT.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Unlicensed
 pragma solidity ^0.8.0;
 
-import "src/interfaces/IERC20.sol";
+import "./IERC20.sol";
 
 /**
  * @dev Interface for LFT tokens.

--- a/src/interfaces/IManager.sol
+++ b/src/interfaces/IManager.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: Unlicensed
 pragma solidity ^0.8.0;
 
-import "src/interfaces/IConfig.sol";
-import "src/interfaces/ICState.sol";
-import "src/interfaces/IERC20.sol";
-import "src/interfaces/ISet.sol";
+import "./IConfig.sol";
+import "./ICState.sol";
+import "./IERC20.sol";
+import "./ISet.sol";
 
 /**
  * @notice The Manager is in charge of the full Cozy protocol. Configuration parameters are defined here, it serves

--- a/src/interfaces/IPToken.sol
+++ b/src/interfaces/IPToken.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Unlicensed
 pragma solidity ^0.8.0;
 
-import "src/interfaces/ILFT.sol";
+import "./ILFT.sol";
 
 /**
  * @notice Users receive protection tokens when purchasing protection. Each protection token contract is associated

--- a/src/interfaces/ISet.sol
+++ b/src/interfaces/ISet.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: Unlicensed
 pragma solidity ^0.8.0;
 
-import "src/interfaces/IConfig.sol";
-import "src/interfaces/ICState.sol";
-import "src/interfaces/ILFT.sol";
+import "./IConfig.sol";
+import "./ICState.sol";
+import "./ILFT.sol";
 
 /**
  * @notice All protection markets live within a set.

--- a/src/interfaces/ITrigger.sol
+++ b/src/interfaces/ITrigger.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: Unlicensed
 pragma solidity ^0.8.0;
 
-import "src/interfaces/ICState.sol";
-import "src/interfaces/ISet.sol";
+import "./ICState.sol";
+import "./ISet.sol";
 
 /**
  * @dev The minimal functions a trigger must implement to work with the Cozy protocol.

--- a/src/interfaces/IUMATrigger.sol
+++ b/src/interfaces/IUMATrigger.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: Unlicensed
 pragma solidity ^0.8.0;
 
-import "src/interfaces/ICState.sol";
-import "src/interfaces/ISet.sol";
+import "./ICState.sol";
+import "./ISet.sol";
 
 /**
  * @notice This is an automated trigger contract which will move markets into a

--- a/src/interfaces/IUMATriggerFactory.sol
+++ b/src/interfaces/IUMATriggerFactory.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.0;
 
 import "uma-protocol/packages/core/contracts/oracle/interfaces/FinderInterface.sol";
-import "src/interfaces/IUMATrigger.sol";
+import "./IUMATrigger.sol";
 
 /**
  * @notice This is a utility contract to make it easy to deploy UMATriggers for


### PR DESCRIPTION
slither in `cozy-protocol-v2` (and presumably `cozy-models-v2`) complains if we're not using relative imports. Updating to make lives for the auditors easier so they don't have to patch it locally